### PR TITLE
Add Roundtable MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,13 @@ This repository contains **MCP (Model Context Protocol) servers** . Each folder 
    - Retrieves LinkedIn profile data via an external API from RapidAPI.  
    - Enables AI models to process professional profile insights.
   
-3. **Fetch PubMed Article Server** 🔗  
-   - Retrieves articles from PubMed given a query.  
+3. **Fetch PubMed Article Server** 🔗
+   - Retrieves articles from PubMed given a query.
+
+4. **[Roundtable](https://github.com/sinaneshat/roundtable-dashboard)** 🤖
+   - Multi-model AI brainstorming — consult a council of AI models that debate your question, then a moderator synthesizes the best answer.
+   - 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs.
+   - Remote MCP endpoint: `https://mcp.roundtable.now/mcp` (Streamable HTTP).
 
 ## 🛠️ How to Use  
 


### PR DESCRIPTION
## Summary

Adds [Roundtable](https://roundtable.now) to the Server Implementations list.

Roundtable is a multi-model AI brainstorming MCP server — consult a council of AI models that debate your question, then a moderator synthesizes the best answer. It provides 13 tools including consult_council, review_code, debug_issue, design_architecture, plan_implementation, and assess_tradeoffs.

- **Website:** https://roundtable.now
- **MCP Endpoint:** https://mcp.roundtable.now/mcp (Streamable HTTP)
- **GitHub:** https://github.com/sinaneshat/roundtable-dashboard