### PR TITLE
Add Packrift MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ This repository contains **MCP (Model Context Protocol) servers** . Each folder 
    - 6 tools: search_agents, get_site_details, get_stats, submit_site, register_monitor, verify_mcp.
    - Endpoint: [nothumansearch.ai/mcp](https://nothumansearch.ai/mcp) | MCP Registry: ai.nothumansearch/search
 
+8. **Packrift MCP** 📦
+   - Remote MCP server for packaging procurement, exact-size SKU lookup, carton-fit recommendations, shipping estimates, and dimensional-weight calculations.
+   - Repository: [Packrift/packrift-mcp](https://github.com/Packrift/packrift-mcp)
+
 ## 🛠️ How to Use  
 
 1. Clone the repository:  


### PR DESCRIPTION
Adds Packrift MCP to the server implementations list as a remote MCP server for packaging procurement and carton-fit workflows.\n\nValidation:\n- Verified https://github.com/Packrift/packrift-mcp returns HTTP 200\n- Ran git diff --check