### PR TITLE
Add TWZRD Agent Intel - Solana x402 trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This repository contains **MCP (Model Context Protocol) servers** . Each folder 
 8. **TWZRD Agent Intel** 🔐
    - Solana-native agent trust scoring via x402 micropayments. Free on-chain preflight checks (account validity, program state, token balances) + paid signed V5 trust receipts settled in <1s.
    - Live endpoint: [intel.twzrd.xyz/mcp](https://intel.twzrd.xyz/mcp) — Streamable HTTP, no install required.
-   - Repository: [twzrd-sol/wzrd-final](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel)
+   - Service: [intel.twzrd.xyz](https://intel.twzrd.xyz)
 
 ## 🛠️ How to Use  
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ This repository contains **MCP (Model Context Protocol) servers** . Each folder 
    - Remote MCP server for packaging procurement, exact-size SKU lookup, carton-fit recommendations, shipping estimates, and dimensional-weight calculations.
    - Repository: [Packrift/packrift-mcp](https://github.com/Packrift/packrift-mcp)
 
+8. **TWZRD Agent Intel** 🔐
+   - Solana-native agent trust scoring via x402 micropayments. Free on-chain preflight checks (account validity, program state, token balances) + paid signed V5 trust receipts settled in <1s.
+   - Live endpoint: [intel.twzrd.xyz/mcp](https://intel.twzrd.xyz/mcp) — Streamable HTTP, no install required.
+   - Repository: [twzrd-sol/wzrd-final](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel)
+
 ## 🛠️ How to Use  
 
 1. Clone the repository:  


### PR DESCRIPTION
## Summary

Adds **TWZRD Agent Intel** — a Solana-native agent trust scoring MCP server.

**Server details:**
- **Live endpoint**: `https://intel.twzrd.xyz/mcp` (Streamable HTTP, no install required)
- **Service**: https://intel.twzrd.xyz
- **MCP Registry**: `xyz.twzrd.intel/twzrd-agent-intel`

**What it does:**
- 4 free tools score any Solana wallet (account validity, program state, token balances, on-chain activity)
- Paid `get_trust_receipt` returns a cryptographically signed `twzrd.receipt.v5` trust token via HTTP 402 + USDC on Solana (<1s settlement)

**Quick config:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```