### PR TITLE
Add Screenpipe MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ This repository contains **MCP (Model Context Protocol) servers** . Each folder 
    - Remote MCP server for packaging procurement, exact-size SKU lookup, carton-fit recommendations, shipping estimates, and dimensional-weight calculations.
    - Repository: [Packrift/packrift-mcp](https://github.com/Packrift/packrift-mcp)
 
+9. **Screenpipe MCP** 🖥️
+   - Local-first MCP server backed by 24/7 screen and microphone recording with OCR, accessibility-tree, and transcript indexing.
+   - Lets AI assistants search and answer questions over everything you've seen, heard, and typed on your machine.
+   - Install: `claude mcp add screenpipe -- npx -y screenpipe-mcp@latest`
+   - Repository: [screenpipe/screenpipe](https://github.com/screenpipe/screenpipe)
+
 ## 🛠️ How to Use  
 
 1. Clone the repository:  


### PR DESCRIPTION
Adds Screenpipe MCP to the server implementations list.

- Open-source, local-first MCP server backed by 24/7 screen + mic recording with OCR, accessibility-tree, and transcript indexing
- Lets AI assistants (Claude Desktop, Cursor, Cline, Continue, any MCP-compatible client) search and answer questions over everything you've seen, heard, and typed on your machine
- Cross-platform (macOS / Windows / Linux), works with Ollama for fully local inference
- Install: `claude mcp add screenpipe -- npx -y screenpipe-mcp@latest`
- Repository: https://github.com/screenpipe/screenpipe

Followed the format of the recently merged entry (#8 Packrift MCP): numbered slot, bold name + emoji, short description, optional install line, repository link.

Disclosure: this entry was prepared by Screenpipe's automated contribution agent and checked against the repo's existing entries for formatting. I'm the maintainer (louis@screenpi.pe) — happy to adjust copy, change the emoji, or close if it isn't a fit.