### PR TITLE
Add Autoposting MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ This repository contains **MCP (Model Context Protocol) servers** . Each folder 
    - Install: `claude mcp add screenpipe -- npx -y screenpipe-mcp@latest`
    - Repository: [screenpipe/screenpipe](https://github.com/screenpipe/screenpipe)
 
+10. **Autoposting MCP** 📣
+   - Remote MCP server for social publishing: draft, schedule and publish posts to X, LinkedIn, Instagram, Threads and YouTube, plus AI carousels and video clipping.
+   - Streamable HTTP with OAuth 2.1 Dynamic Client Registration, so there is nothing to install and no client secret to paste.
+   - Install: `claude mcp add --transport http autoposting https://app.autoposting.ai/mcp`
+   - Repository: [Autoposting-ai/autoposting-mcp](https://github.com/Autoposting-ai/autoposting-mcp)
+
 ## 🛠️ How to Use  
 
 1. Clone the repository:  


### PR DESCRIPTION
Adds Autoposting as entry 10 under Server Implementations, matching the existing entry format.

Autoposting is a hosted MCP server at `https://app.autoposting.ai/mcp` (Streamable HTTP, OAuth 2.1 with Dynamic Client Registration). It covers drafting, scheduling and publishing posts to X, LinkedIn, Instagram, Threads and YouTube, plus carousel generation and video clipping.

- Repository: https://github.com/Autoposting-ai/autoposting-mcp
- Docs: https://docs.autoposting.ai/mcp/overview
- Official MCP registry entry: `ai.autoposting/autoposting`