### PR TITLE
Add AI Applyd MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,8 @@ This project is open-source under the **MIT License**.
 - - [OpenAPI to MCP Cloud Bridge](https://mcp-bridge-saas.onrender.com) — A zero-setup, hosted cloud bridge that dynamically transforms standard OpenAPI JSON specifications into remote Model Context Protocol (MCP) servers over SSE. Source code available on [GitHub](https://github.com/notsariedo/openapi-mcp-gateway).
 - [Liftli](https://github.com/liftli-ai/liftli-mcp) — Remote MCP server that acts as a head of content for LinkedIn, X and Substack: extracts your writing voice from your own posts, turns voice notes, meeting transcripts and GitHub activity into post ideas, drafts and critiques them, then schedules or publishes through the official platform APIs. 54 tools, one-tap approval, no scraping.
 - [GoodMemory](https://github.com/hjqcan/GoodMemory) — Local-first, auditable memory for coding agents and MCP clients. Uses SQLite by default, exposes read-only context, trace, search, records, artifact, and stats tools, and keeps durable writes opt-in with inspect, revise, forget, and export controls. Install with `npm install -g goodmemory@0.7.2`.
+11. **AI Applyd** 💼
+   - ATS resume scoring, job-description analysis, interview prep, cover letters, resume building and auto-apply that submits on the employer's own hiring system.
+   - Hosted remote server (Streamable HTTP + OAuth 2.1) - no install, no config file.
+   - Repository: [whateverneveranywhere/aiapplyd-mcp](https://github.com/whateverneveranywhere/aiapplyd-mcp) | Website: [aiapplyd.com](https://aiapplyd.com/mcps)
+


### PR DESCRIPTION
Adds **AI Applyd**, a hosted remote MCP server for job seekers.

- Repo: https://github.com/whateverneveranywhere/aiapplyd-mcp
- Endpoint: `https://mcp.aiapplyd.com/mcp` (Streamable HTTP, OAuth 2.1 + dynamic client registration)
- Listed on the official MCP Registry as `io.github.whateverneveranywhere/aiapplyd` and on Smithery

Tools cover ATS resume scoring, job-description analysis, interview prep, cover letters, resume building and auto-apply. Every tool declares `readOnlyHint`/`destructiveHint`. Nothing to install: it is a remote server, so clients connect by URL.

Formatted to match the existing entries in this list.