### PR TITLE
Add Hexis MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,7 @@ This project is open-source under the **MIT License**.
    - Install: `claude mcp add --transport http zopnight https://api.zop.dev/mcp-server --header "Authorization: Bearer zn_pat_YOUR_TOKEN"`
    - Docs: [Zopnight MCP server](https://zop.dev/learn/mcp-server?utm_source=aianytime-awesome-mcp-server&utm_medium=listing&utm_campaign=mcp-directory) | Claude setup: [set up Zopnight MCP for Claude](https://zop.dev/learn/how-to/set-up-zopnight-mcp-for-claude)
 
+13. **Hexis**
+   - Git-backed platform for skills, tools, and context for AI agents.
+   - Remote endpoint: [demo.bevel.software/api/mcp](https://demo.bevel.software/api/mcp)
+   - Repository: [Bevel-Software/Hexis](https://github.com/Bevel-Software/Hexis)


### PR DESCRIPTION
Adds Hexis to the Server Implementations list.

Hexis is a Git-backed platform for skills, tools, and context for AI agents. Its hosted Streamable HTTP endpoint uses OAuth and is available at https://demo.bevel.software/api/mcp.

Validation:
- Repository link returns 200
- MCP endpoint responds with the expected OAuth challenge
- No existing Hexis entry or pull request
- git diff --check passes