### PR TITLE
Add Skillselion to Server Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,9 @@ This project is open-source under the **MIT License**.
    - Install: `claude mcp add --transport http zopnight https://api.zop.dev/mcp-server --header "Authorization: Bearer zn_pat_YOUR_TOKEN"`
    - Docs: [Zopnight MCP server](https://zop.dev/learn/mcp-server?utm_source=aianytime-awesome-mcp-server&utm_medium=listing&utm_campaign=mcp-directory) | Claude setup: [set up Zopnight MCP for Claude](https://zop.dev/learn/how-to/set-up-zopnight-mcp-for-claude)
 
+
+13. **Skillselion** 🧩
+   - On-demand skill loader: searches the Skillselion catalog (79,000+ agent skills, MCP servers, plugins and marketplaces ranked by real install counts) and materializes the matching `SKILL.md` plus its bundled scripts and references into the session mid-task.
+   - 4 tools: `load_skill`, `synthesize_skills` (merges the top ~5 matching skills into one provenance-tagged digest), `search_skillselion`, `top_skillselion`.
+   - Install: `npx -y skillselion-mcp` — stdio, read-only, no auth or API key. MCP Registry: `io.github.skillselion/skillselion-mcp`.
+   - Repository: [skillselion/skillselion-mcp](https://github.com/skillselion/skillselion-mcp) | Website: [skillselion.com](https://skillselion.com)


### PR DESCRIPTION
Adds `skillselion-mcp` as entry 13 under **Server Implementations**.

**What it does:** an on-demand skill loader for coding agents. It searches the Skillselion catalog (79,000+ agent skills, MCP servers, plugins and marketplaces, ranked by real install counts) and pulls the matching `SKILL.md` plus its bundled scripts and references into the running session, so the agent follows a community-proven recipe instead of improvising.

**Metadata**
- Repo: https://github.com/skillselion/skillselion-mcp (MIT)
- npm: `skillselion-mcp` v0.9.6 — `npx -y skillselion-mcp`
- Transport: stdio · Auth: none (read-only, no API key)
- Tools (4): `load_skill`, `synthesize_skills`, `search_skillselion`, `top_skillselion`
- MCP Registry id: `io.github.skillselion/skillselion-mcp` (ACTIVE)

Follows the existing numbered-entry format; README only.