### PR TITLE
Add AISOTools MCP — hosted catalog search over 1,766 AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ This repository contains **MCP (Model Context Protocol) servers** . Each folder 
    - Install: `claude mcp add --transport http autoposting https://app.autoposting.ai/mcp`
    - Repository: [Autoposting-ai/autoposting-mcp](https://github.com/Autoposting-ai/autoposting-mcp)
 
+11. **AISOTools MCP** 🔎
+   - Remote MCP server over a curated catalog of 1,766 AI tools: keyword/category/pricing search, full records (features, pros, cons, pricing tiers), side-by-side comparison of 2-5 products, and alternatives lookup.
+   - Streamable HTTP, read-only, no API key and no account. Every result carries a canonical citation URL, and sponsored placements are flagged with a `sponsored` boolean so an assistant can disclose them.
+   - Install: `claude mcp add --transport http aisotools https://aisotools.com/api/mcp`
+   - Repository: [shibley/aisotools-mcp-server](https://github.com/shibley/aisotools-mcp-server) | Docs: [aisotools.com/mcp](https://aisotools.com/mcp) | MCP Registry: io.github.shibley/aisotools
+
 ## 🛠️ How to Use  
 
 1. Clone the repository:  


### PR DESCRIPTION
Adds AISOTools MCP as entry 11 under Server Implementations, in the same remote-endpoint style as the existing nothumansearch, Autoposting and Packrift entries.

**What it does:** read-only MCP server over a curated catalog of 1,766 AI tools — keyword/category/pricing search, full per-tool records (features, pros, cons, pricing tiers), side-by-side comparison of 2–5 products, and alternatives lookup. Five tools, all read-only.

**Why it may be useful here:** it answers "which AI tool should I use for X" from a maintained catalog instead of the model guessing, and every result carries a canonical citation URL. Sponsored placements are returned with an explicit `sponsored` boolean (and it flips to false the moment a paid window lapses), so an assistant can disclose them rather than pass them off as neutral picks.

- Endpoint: `https://aisotools.com/api/mcp` (streamable HTTP, no API key, no account)
- Install: `claude mcp add --transport http aisotools https://aisotools.com/api/mcp`
- Docs: https://aisotools.com/mcp
- Repo: https://github.com/shibley/aisotools-mcp-server
- Official MCP Registry: `io.github.shibley/aisotools` (status: active)

Handshake verified today against the live endpoint (`initialize` → 2025-06-18, `tools/list` → 5 tools). Happy to reword or move it if you'd rather it sat elsewhere.