### PR TITLE
Add SandBase CLI MCP bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ This repository contains **MCP (Model Context Protocol) servers** . Each folder 
    - Install: `claude mcp add --transport http aisotools https://aisotools.com/api/mcp`
    - Repository: [shibley/aisotools-mcp-server](https://github.com/shibley/aisotools-mcp-server) | Docs: [aisotools.com/mcp](https://aisotools.com/mcp) | MCP Registry: io.github.shibley/aisotools
 
+12. **SandBase CLI** 🧰
+   - Agent-first CLI and stdio MCP bridge for discovering, inspecting, and running 2,000+ AI models and APIs with one account.
+   - Covers web and social search, scraping, multimodal generation, data APIs, and sandboxes through six progressively disclosed MCP tools.
+   - Install: `npx -y @sandbaseai/cli connect`
+   - Repository: [sandbaseai/cli](https://github.com/sandbaseai/cli) | Website: [sandbase.ai](https://sandbase.ai)
+
 ## 🛠️ How to Use  
 
 1. Clone the repository:  

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This repository contains **MCP (Model Context Protocol) servers** . Each folder 
    - Repository: [shibley/aisotools-mcp-server](https://github.com/shibley/aisotools-mcp-server) | Docs: [aisotools.com/mcp](https://aisotools.com/mcp) | MCP Registry: io.github.shibley/aisotools
 
 12. **SandBase CLI** 🧰
-   - Agent-first CLI and stdio MCP bridge for discovering, inspecting, and running 2,000+ AI models and APIs with one account.
+   - Agent-first CLI and stdio MCP bridge for discovering, inspecting, and running 2,000+ AI models with one account.
    - Covers web and social search, scraping, multimodal generation, data APIs, and sandboxes through six progressively disclosed MCP tools.
    - Install: `npx -y @sandbaseai/cli connect`
    - Repository: [sandbaseai/cli](https://github.com/sandbaseai/cli) | Website: [sandbase.ai](https://sandbase.ai)


### PR DESCRIPTION
Adds SandBase CLI as entry 12 under Server Implementations, following the numbered format used by the recently merged entries.

**What it does:** a local stdio MCP bridge that lets agents discover, inspect, and run 2,000+ AI models through six progressively disclosed tools. The catalog covers web and social search, scraping, multimodal generation, data APIs, and sandboxes.

- Install: `npx -y @sandbaseai/cli connect`
- Repo: https://github.com/sandbaseai/cli
- Website: https://sandbase.ai
- License: Apache-2.0

Validation: `git diff --check` passes; the npm package is public and both linked sites return HTTP 200.

Disclosure: I am affiliated with SandBase, and this contribution was prepared with AI assistance.