### PR TITLE
Add Agent QA MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,8 @@ This project is open-source under the **MIT License**.
    - 4 tools: `load_skill`, `synthesize_skills` (merges the top ~5 matching skills into one provenance-tagged digest), `search_skillselion`, `top_skillselion`.
    - Install: `npx -y skillselion-mcp` — stdio, read-only, no auth or API key. MCP Registry: `io.github.skillselion/skillselion-mcp`.
    - Repository: [skillselion/skillselion-mcp](https://github.com/skillselion/skillselion-mcp) | Website: [skillselion.com](https://skillselion.com)
+
+14. **Agent QA** 🧪
+   - Local stdio MCP server for authoring, validating, running, and inspecting natural-language web and mobile regression tests with persistent test memory.
+   - Install: `npx -y agent-qa mcp`
+   - Repository: [vostride/agent-qa](https://github.com/vostride/agent-qa)


### PR DESCRIPTION
## Summary

Add [Agent QA](https://github.com/vostride/agent-qa) as entry 14 in the MCP server implementations list.

The entry gives the exact `npx -y agent-qa mcp` stdio startup command and a factual description of its natural-language web/mobile regression test authoring, validation, execution, inspection, and persistent test memory.

## Validation

- confirmed Agent QA was not already listed or proposed by this account
- kept the change to one numbered entry
- `git diff --check` passes

Disclosure: I am affiliated with Agent QA. Its current FSL-1.1-ALv2 release is source-available rather than OSI open source; each release converts to Apache-2.0 after two years. Configured model-provider accounts and usage charges are separate.
