### PR TITLE
Add Pocket Drives

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,8 @@ This project is open-source under the **MIT License**.
    - Free remote MCP for live web search and URL fetching.
    - Streamable HTTP with no account or API key required.
    - Endpoint: `https://search.parallel.ai/mcp` | Tools: `web_search`, `web_fetch` | [Docs](https://docs.parallel.ai/integrations/mcp/search-mcp)
+
+16. **Pocket Drives** 🚗
+   - Search peer-to-peer luxury, exotic, and EV rentals from independent hosts.
+   - Remote Streamable HTTP at https://pocketdrives.ai/mcp, no auth.
+   - Repo: https://github.com/RevList/pocket-drives-mcp


### PR DESCRIPTION
Adds Pocket Drives as numbered server 16.

```
16. **Pocket Drives** 🚗
   - Search peer-to-peer luxury, exotic, and EV rentals from independent hosts.
   - Remote Streamable HTTP at https://pocketdrives.ai/mcp, no auth.
   - Repo: https://github.com/RevList/pocket-drives-mcp
```

I maintain this (PocketList Inc / Pocket Drives). Public remote Streamable HTTP MCP, no auth. Independent hosts; not a fleet. Booking finishes in the iOS app (id 6758782510).