### PR TITLE
Add ParlayAPI to Finance & markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Servers built by the community. Entries are alphabetical within each category.
 - **[AskCyborg](https://github.com/Ask-Cyborg/askcyborg-mcp)** `http` — Stress-tests public and private companies through analyst debate: reports, scores, comparisons, competitors, recent developments. Anonymous free tier, no API key. Endpoint: `https://mcp.askcyborg.com/mcp`
 - **[EventTrader](https://github.com/eventtrader/event-trader-mcp)** `http` — Prediction-market trading: place bets, TGE token price predictions, real-time orderbooks, agent cloning, due-diligence scoring. [Platform](https://cymetica.com)
 - **[Helium](https://github.com/connerlambden/helium-mcp)** `http` — Real-time news with 37-dimension bias scoring, ML options pricing, and live market data. [Interactive demo](https://connerlambden.github.io/helium-news-explorer/) · [REST API](https://heliumtrades.com/mcp-page/)
+- **[ParlayAPI](https://github.com/JacobiusMakes/parlay-api-mcp)** `stdio` — Sports odds, player props, public event discovery, and account usage through ParlayAPI; account data tools require each user's own API key and allowances. Install: `uvx --from parlayapi-mcp==0.3.5 parlayapi-mcp`
 
 ### Marketing, content & social
 


### PR DESCRIPTION
## What is this?

- [x] Adding a server to the community directory

**Server name:** ParlayAPI
**Link:** https://github.com/JacobiusMakes/parlay-api-mcp
**Category it goes in:** Finance & markets, the closest existing category alongside EventTrader; no new category added.

## Checklist

- [x] One server only
- [x] Alphabetical bullet with the required format and stdio tag
- [x] Concise factual description, no tracking parameters
- [x] Source link resolves and package is public
- [x] No duplicate name or domain in the README or issue/PR search
- [x] Speaks MCP; published command passed initialization and 22-tool discovery

## Anything else?

I maintain the linked server. Account data tools require each user's own API key and allowances; no data redistribution rights or native-client testing are claimed. The exact pinned uvx launch command reuses the completed metadata-only check. Upstream `.github/scripts/lint_readme.py` passes all 34 entries.
